### PR TITLE
Fix creation date and email addresses in AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,11 +1,11 @@
-TDS was originally created at if(we) in 2001.  The main developers are:
+TDS was originally created at if(we) in 2011.  The main developers are:
 
-    Kenneth Lareau <klareau@ifwe.co>
-    Karandeep Nagra <knagra@ifwe.co>
+    Kenneth Lareau <elessar@numenor.org>
+    Karandeep Nagra
 
 Other contributors to the project (with many thanks):
 
     Mike Dougherty
     Corey Hickey <chickey@ifwe.co>
-    Christopher A. Stelma <cstelma@ifwe.co>
+    Christopher A. Stelma
     Thomas Van Buskirk <tvanbuskirk@ifwe.co>


### PR DESCRIPTION
The date was off by 10 years and some email addresses are no longer valid (I've updated the ones I know and have permission to do so, and blanked the others).